### PR TITLE
fix: remove unused package permissions

### DIFF
--- a/.github/workflows/on-push-main-version-and-tag.yaml
+++ b/.github/workflows/on-push-main-version-and-tag.yaml
@@ -5,7 +5,6 @@ on:
       - main
 
 permissions:
-  packages: write
   contents: write
 
 jobs:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -59,7 +59,7 @@ on:
         required: false
 
       GH_PAT:
-        description: 'GitHub Personal Access Token (PAT) with repo,write:packages scopes'
+        description: 'GitHub Personal Access Token (PAT) with repository write access for git operations'
         required: false
 
 jobs:
@@ -69,7 +69,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
 
     permissions:
-      packages: write
       contents: write
 
     steps:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The GitHub Actions workflow accepts the following inputs:
 | Secret | Required | Description |
 |--------|----------|-------------|
 | `DEPLOY_KEY` | No | SSH deploy key for git operations when `useDeployKey` is true |
-| `GH_PAT` | No | GitHub Personal Access Token with repo,write:packages scopes when `usePAT` is true |
+| `GH_PAT` | No | GitHub Personal Access Token with repository write access for git operations when `usePAT` is true |
 
 > **Note:** This workflow creates a tag, which can trigger other workflows. The built-in `GITHUB_TOKEN` does not allow a workflow to trigger another workflow, so you need to use either a deploy key or a GitHub personal access token. We recommend using a deploy key per repo as they can be generated, forgotten, and rotated easily.
 


### PR DESCRIPTION
## Summary

- remove the unused `packages: write` permission from the reusable workflow
- remove the same permission from the repository wrapper workflow
- update PAT documentation to require repository write access for git operations, not package publishing

## Verification

- `actionlint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guidance for the `GH_PAT` secret to require repository write access.
  * Removed references to package publishing permissions from the documented requirements.

* **Chores**
  * Reduced workflow permissions by removing package write access while retaining repository content write access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->